### PR TITLE
there's no text item anymore so it generates a broken block and an er…

### DIFF
--- a/event/twitter.php
+++ b/event/twitter.php
@@ -18,7 +18,7 @@
         $eventIconStatus = "favorite";
         $eventTitle = '<span>I faved tweet;</span>';
         $eventUrl = $content["LinkToTweet"];
-        $eventContent = $content["Text"];
+        $eventContent = $content["TweetEmbedCode"];
 
     }
 


### PR DESCRIPTION
…ror, instead, use the tweet embed code